### PR TITLE
Small fixes for TCHES builds

### DIFF
--- a/iacrtrans.cls
+++ b/iacrtrans.cls
@@ -223,7 +223,7 @@
 \fancyfoot[L]{\small Licensed under Creative Commons License CC-BY 4.0.\\
 \publname{} ISSN~\IACR@ISSN, Vol.~\IACR@vol, No.~\IACR@no, pp.~\IACR@fp--\IACR@lp\\  DOI:\IACR@DOI}
 \fi
-\fancyfoot[R]{\includegraphics[height=2ex]{CC-by}}
+\fancyfoot[R]{\includegraphics[clip,height=2ex]{CC-by}}
 \if@loadhr
   \hypersetup{pdfcopyright={Licensed under Creative Commons License CC-BY 4.0.}}
   \hypersetup{pdflicenseurl={http://creativecommons.org/licenses/by/4.0/}}

--- a/settings.tches.tex
+++ b/settings.tches.tex
@@ -5,5 +5,5 @@
 
 \setISSN{XXXX-XXXX}
 \makeatletter
-\setDOI{10.13154/tosc.v\IACR@vol.i\IACR@no.\IACR@fp-\IACR@lp}
+\setDOI{10.13154/tches.v\IACR@vol.i\IACR@no.\IACR@fp-\IACR@lp}
 \makeatother


### PR DESCRIPTION
While working on the first TCHES issue, two problems came up:
 * One of our papers uses a `tex->dvi->pdf` build (instead of `pdflatex`). In this configuration, pdf files cannot be used as images, so we are using an `eps` file for the CC-by logo. However, lines (some sort of clip marks) appear, but can be suppressed by the `clip` option added in the `iacrtrans.cls`. This should not interfere with any `pdflatex` builds.
 * The DOI structure in `settings.tches.tex` is wrong. It should say `tches` instead of `tosc`