### PR TITLE
Use correct journal title in pdf subject

### DIFF
--- a/iacrtrans.cls
+++ b/iacrtrans.cls
@@ -275,7 +275,7 @@ Received: \IACR@Received, \if@IACR@Revised Revised: \IACR@Revised, \fi Accepted:
 \if@loadhr
   \hypersetup{pdfcopyright={Licensed under Creative Commons License CC-BY 4.0.}}
   \hypersetup{pdflicenseurl={http://creativecommons.org/licenses/by/4.0/}}
-  \hypersetup{pdfsubject={IACR Transactions on Symmetric Cryptology, DOI:\IACR@DOI}}
+  \hypersetup{pdfsubject={\publname{}, DOI:\IACR@DOI}}
   \hypersetup{pdflang=en}
 \fi
 \fi\fi

--- a/settings.tches.tex
+++ b/settings.tches.tex
@@ -7,3 +7,5 @@
 \makeatletter
 \setDOI{10.13154/tches.v\IACR@vol.i\IACR@no.\IACR@fp-\IACR@lp}
 \makeatother
+
+\setkeys{IACR}{journal=tches}


### PR DESCRIPTION
Right now, the PDF metadata subject is always set to ToSC, we can simply use `\publname` here to be compatible with for both journals.