### PR TITLE
Rework dates

### DIFF
--- a/iacrtrans.cls
+++ b/iacrtrans.cls
@@ -82,7 +82,10 @@
 \def\IACR@Revised{20XX-XX-XX}
 \def\IACR@Accepted{20XX-XX-XX}
 \def\IACR@Published{20XX-XX-XX}
+\newif\if@IACR@Received \@IACR@Receivedfalse
 \newif\if@IACR@Revised \@IACR@Revisedfalse
+\newif\if@IACR@Accepted \@IACR@Acceptedfalse
+\newif\if@IACR@Published \@IACR@Publishedfalse
 
 \newcommand{\setfirstpage}[1]{\def\IACR@fp{#1}\setcounter{page}{#1}}
 \newcommand{\setlastpage}[1]{\def\IACR@lp{#1}}
@@ -91,10 +94,10 @@
 \newcommand{\setISSN}[1]{\def\IACR@ISSN{#1}}
 \newcommand{\setDOI}[1]{\def\IACR@DOI{#1}}
 
-\newcommand{\setReceived}[1]{\def\IACR@Received{#1}}
+\newcommand{\setReceived}[1]{\@IACR@Receivedtrue\def\IACR@Received{#1}}
 \newcommand{\setRevised}[1]{\@IACR@Revisedtrue\def\IACR@Revised{#1}}
-\newcommand{\setAccepted}[1]{\def\IACR@Accepted{#1}}
-\newcommand{\setPublished}[1]{\def\IACR@Published{#1}}
+\newcommand{\setAccepted}[1]{\@IACR@Acceptedtrue\def\IACR@Accepted{#1}}
+\newcommand{\setPublished}[1]{\@IACR@Publishedtrue\def\IACR@Published{#1}}
 
 % Options
 \newif\if@loadhr
@@ -261,17 +264,23 @@
 \fancyhf{} % clear all header and footer fields
 \if@submission\else\if@preprint\else
 \if@loadhr
-\fancyhead[L]{\small \publname{}\\
-ISSN~\IACR@ISSN, Vol.~\IACR@vol, No.~\IACR@no, pp.~\IACR@fp--\IACR@lp. \hfill \href{https://doi.org/\IACR@DOI}{DOI:\IACR@DOI}}
-\fancyfoot[L]{\small Licensed under \href{http://creativecommons.org/licenses/by/4.0/}{Creative Commons License CC-BY 4.0.}\\
-Received: \IACR@Received, \if@IACR@Revised Revised: \IACR@Revised, \fi Accepted: \IACR@Accepted, Published: \IACR@Published}
-\else
-\fancyhead[L]{\small \publname{}\\
-ISSN~\IACR@ISSN, Vol.~\IACR@vol, No.~\IACR@no, pp.~\IACR@fp--\IACR@lp. \hfill  DOI:\IACR@DOI}
-\fancyfoot[L]{\small Licensed under Creative Commons License CC-BY 4.0.\\
-Received: \IACR@Received, \if@IACR@Revised Revised: \IACR@Revised, \fi Accepted: \IACR@Accepted, Published: \IACR@Published}
-\fi
-\fancyfoot[R]{\includegraphics[clip,height=2ex]{CC-by}}
+\fancyhead[L]{%
+\small%
+\publname{}\\
+ISSN~\IACR@ISSN, Vol.~\IACR@vol, No.~\IACR@no, pp.~\IACR@fp--\IACR@lp. \hfill{}%
+\if@loadhr\href{https://doi.org/\IACR@DOI}{DOI:\IACR@DOI}}\else {DOI:\IACR@DOI}\fi%
+\fancyfoot[L]{
+\small%
+Licensed under %
+\if@loadhr\href{http://creativecommons.org/licenses/by/4.0/}{Creative Commons License CC-BY 4.0.}%
+\else{Creative Commons License CC-BY 4.0.}\fi%
+\hfill{}%
+\includegraphics[clip,height=2ex]{CC-by}\\[.1em]%
+\if@IACR@Received Received: \IACR@Received \hfill{} \fi%
+\if@IACR@Revised Revised: \IACR@Revised \hfill{} \fi%
+\if@IACR@Accepted Accepted: \IACR@Accepted \hfill{} \fi%
+\if@IACR@Published Published: \IACR@Published \fi%
+}%
 \if@loadhr
   \hypersetup{pdfcopyright={Licensed under Creative Commons License CC-BY 4.0.}}
   \hypersetup{pdflicenseurl={http://creativecommons.org/licenses/by/4.0/}}


### PR DESCRIPTION
With 73fdead2fa699cbfedabf190f286e0f87aea13b1 the template now includes the dates for *Received*, *Accepted*,  *Published* and optionally *Revised*. This does not (yet) apply to TCHES, as there is no clear definition, what these dates would mean.

The commit in this PR makes all of the dates optional. Also, it changes the alignment, with the dates evenly spread on one line (using `\hfill`s). Also, i cleaned up the `@loadhr` if-else-statements in the header and footer.
Here are two examples of the new footer:
 * With full dates
![01](https://user-images.githubusercontent.com/6842104/74533498-050e3e00-4f32-11ea-924a-30b7ce8b87b5.png)
* With only the publication date (the TCHES case):
![03](https://user-images.githubusercontent.com/6842104/74533528-1c4d2b80-4f32-11ea-88b6-a7c00c906508.png)

