### PR TITLE
Update DOI for TCHES

### DIFF
--- a/settings.tches.tex
+++ b/settings.tches.tex
@@ -5,7 +5,7 @@
 
 \setISSN{2569-2925}
 \makeatletter
-\setDOI{10.13154/tches.v\IACR@vol.i\IACR@no.\IACR@fp-\IACR@lp}
+\setDOI{10.46586/tches.v\IACR@vol.i\IACR@no.\IACR@fp-\IACR@lp}
 \makeatother
 
 \setkeys{IACR}{journal=tches}


### PR DESCRIPTION
The DOI provider for TCHES was changed. The new DOI has the prefix 10.46586. This new prefix had already been used in TCHES issue v2021i1.