### PR TITLE
added orcid command

### DIFF
--- a/iacrdoc.tex
+++ b/iacrdoc.tex
@@ -13,7 +13,7 @@
 \documentclass{iacrtrans}
 \usepackage[utf8]{inputenc}
 
-\author{Gaëtan Leurent\inst{1} \and Friedrich Wiemer\inst{2}}
+\author{Gaëtan Leurent\inst{1}\orcid{1234-5678-9012-3456} \and Friedrich Wiemer\inst{2}\orcid{0000-1111-2222-3333}}
 \institute{Inria, Paris, France, \email{gaetan.leurent@inria.fr} \and
            Ruhr-Universität Bochum, Bochum, Germany, \email{friedrich.wiemer@rub.de}}
 \title[\texttt{iacrtans} class documentation]{\publname}

--- a/iacrtrans.cls
+++ b/iacrtrans.cls
@@ -640,5 +640,12 @@
 \RequirePackage[T1]{fontenc}
 \RequirePackage{lmodern}
 
+% OrcID
+\RequirePackage{xcolor}
+\RequirePackage{fontawesome5}
+
+\definecolor{orcidlogocol}{rgb}{0.65, 0.807, 0.223}
+\newcommand{\orcid}[1]{$\,$\href{https://orcid.org/#1}{\textcolor{orcidlogocol}{\faOrcid}}}
+
 \endinput
 %end of file iacrtrans.cls


### PR DESCRIPTION
I've added a command `\orcid` to the IACR style class that users can easily include. The command depends on the packages `xcolor` and `fontawesome5` which should be readily available in almost any tex-system (on Debian and Ubuntu it's e.g. `texlive-fonts-extra`).