### PR TITLE
Fixed bug with affiliation footnote numbering for >=10 affiliations

### DIFF
--- a/iacrtrans.cls
+++ b/iacrtrans.cls
@@ -244,7 +244,7 @@
         \vskip 1em\par
         \small
         \setcounter{IACR@author@cnt}{1}%
-        \def\and{\par\stepcounter{IACR@author@cnt}$^\theIACR@author@cnt$~}
+        \def\and{\par\stepcounter{IACR@author@cnt}$^{\theIACR@author@cnt}$~}
         \ifnum\IACR@inst@last>1 $^1$~\fi\ignorespaces%
         \@institute
         \fi


### PR DESCRIPTION
On papers with more than 9 affiliations, the "footnote" 10 isn't fully superscripted, only the 1 is, the 0 is not. This PR fixes this.