### PR TITLE
Small typo in template bilbio -> biblio

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -77,7 +77,7 @@ unconditionally secure in \autoref{sec:main}.
 \bibliography{abbrev3,crypto,biblio}
 %%%% NOTES
 % - Download abbrev3.bib and crypto.bib from https://cryptobib.di.ens.fr/
-% - Use bilbio.bib for additional references not in the cryptobib database.
+% - Use biblio.bib for additional references not in the cryptobib database.
 %   If possible, take them from DBLP.
 
 \end{document}


### PR DESCRIPTION
This PR is fixing a small typo in the template.tex:  `bilbio.bib` is not the one being used for bibliography, but `biblio.bib` is.