### PR TITLE
Change sectsty to titlesec in iacrtrans.cls

### DIFF
--- a/iacrtrans.cls
+++ b/iacrtrans.cls
@@ -176,7 +176,7 @@
 \RequirePackage[a4paper,hscale=0.65,vscale=0.75,marginratio=1:1,marginparwidth=2.7cm]{geometry}
 \RequirePackage{afterpage}
 % Title fonts: bf+sf
-\usepackage{titlesec}
+\RequirePackage{titlesec}
 \titleformat*{\section}{\sffamily\boldmath}
 \titleformat*{\subsection}{\sffamily\boldmath}
 \titleformat*{\subsubsection}{\sffamily\boldmath}

--- a/iacrtrans.cls
+++ b/iacrtrans.cls
@@ -177,7 +177,7 @@
 \RequirePackage{afterpage}
 % Title fonts: bf+sf
 \RequirePackage{titlesec}
-\titleformat*{\section}{\sffamily\boldmath}
+\titleformat*{\section}{\sffamily\Large\bfseries\boldmath}
 \titleformat*{\subsection}{\sffamily\boldmath}
 \titleformat*{\subsubsection}{\sffamily\boldmath}
 \titleformat*{\paragraph}{\sffamily\boldmath}

--- a/iacrtrans.cls
+++ b/iacrtrans.cls
@@ -176,8 +176,12 @@
 \RequirePackage[a4paper,hscale=0.65,vscale=0.75,marginratio=1:1,marginparwidth=2.7cm]{geometry}
 \RequirePackage{afterpage}
 % Title fonts: bf+sf
-\RequirePackage{sectsty}
-\allsectionsfont{\sffamily\boldmath}
+\usepackage{titlesec}
+\titleformat*{\section}{\sffamily\boldmath}
+\titleformat*{\subsection}{\sffamily\boldmath}
+\titleformat*{\subsubsection}{\sffamily\boldmath}
+\titleformat*{\paragraph}{\sffamily\boldmath}
+\titleformat*{\subparagraph}{\sffamily\boldmath}
 % Also for descriptions
 \renewcommand*\descriptionlabel[1]{\hspace\labelsep
                                    \normalfont\bfseries\sffamily\boldmath #1}

--- a/iacrtrans.cls
+++ b/iacrtrans.cls
@@ -177,11 +177,11 @@
 \RequirePackage{afterpage}
 % Title fonts: bf+sf
 \RequirePackage{titlesec}
-\titleformat*{\section}{\sffamily\Large\bfseries\boldmath}
-\titleformat*{\subsection}{\sffamily\boldmath}
-\titleformat*{\subsubsection}{\sffamily\boldmath}
-\titleformat*{\paragraph}{\sffamily\boldmath}
-\titleformat*{\subparagraph}{\sffamily\boldmath}
+\titleformat{\section}{\sffamily\Large\bfseries\boldmath}{\thesection}{1em}{}
+\titleformat{\subsection}{\sffamily\large\bfseries\boldmath}{\thesubsection}{1em}{}
+\titleformat{\subsubsection}{\sffamily\normalsize\bfseries\boldmath}{\thesubsubsection}{1em}{}
+\titleformat{\paragraph}[runin]{\sffamily\normalsize\bfseries\boldmath}{\theparagraph}{1em}{}
+\titleformat{\subparagraph}[runin]{\sffamily\normalsize\bfseries\boldmath}{\thesubparagraph}{1em}{}
 % Also for descriptions
 \renewcommand*\descriptionlabel[1]{\hspace\labelsep
                                    \normalfont\bfseries\sffamily\boldmath #1}


### PR DESCRIPTION
In this version a few lines have been changed to replace sectsty by titlesec.

The package titlesec [3] functions equivalently to sectsty, although it is a bit more complex and powerful (it is referenced a few times in the sectsty documentation [1], likewise titlesec mentions sectsty [2]).

The biggest reason for this change is that it gets rid of these annoying warnings when using sectsty (i have not found a way to suppress them when still keeping sectsty):
```
LaTeX Warning: Command \underbar  has changed
LaTeX Warning: Command \underline has changed
```

This is quite a pedantic reason for a change, I know. These warnings could be ignored with no consequence. 

On the technical side: a few lines in iacrtrans.cls were changed, There is no direct `\allsectionsfont` equivalent in titlesec, but \section, \subsection, \subsubsection, \paragraph and \subparagraph are all of the sectional headings in the `article` document class (which iacrtrans herits from), so individually specifying each `\titleformat` is equivalent. 

[1] https://distrib-coffee.ipsl.jussieu.fr/pub/mirrors/ctan/macros/latex/contrib/sectsty/sectsty.pdf
[2] https://ctan.ceremade.dauphine.fr/macros/latex/contrib/titlesec/titlesec.pdf
[3] https://ctan.org/pkg/titlesec