### PR TITLE
Change bibliography style to alphaurl

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -73,7 +73,7 @@ unconditionally secure in \autoref{sec:main}.
 
 
 %%%% 8. BILBIOGRAPHY %%%%
-\bibliographystyle{alpha}
+\bibliographystyle{alphaurl}
 \bibliography{abbrev3,crypto,biblio}
 %%%% NOTES
 % - Download abbrev3.bib and crypto.bib from https://cryptobib.di.ens.fr/


### PR DESCRIPTION
Should we include DOIs in the references? 
I am not sure if `\bibliographystyle{alpha}` is removing the DOIs from the references.